### PR TITLE
Timesheet: fixed layout issues; total hours formatted

### DIFF
--- a/traq/templates/accounts/timesheet.html
+++ b/traq/templates/accounts/timesheet.html
@@ -13,12 +13,13 @@
         margin-bottom:0;
     }
     .dl-horizontal dt{
-    width: 120px;
-    padding-right: 1em;
+        width: 120px;
+        padding-right: 1em;
+        
     }
 
     .dl-horizontal dd{
-        margin-left: 0;
+        margin-left: 120px;
     }
     .submit {
         position: absolute;
@@ -27,6 +28,9 @@
         height: 34px;
         padding-right: 15px;
         padding-left: 15px;
+    }
+    #quicklook{
+        width:220px;
     }
 
 </style>
@@ -71,7 +75,7 @@
             {% for date, works in work_by_date %}
                 <tr>
                     <td class="date_col">
-                        <div class="panel panel-default">
+                        <div id="quicklook" class="panel panel-default">
                             <div class="panel-heading">
                                 <h4>{{ date|date:"D, d M Y" }}</h4>
                             </div>
@@ -83,7 +87,7 @@
                                     <dt>Out:</dt>
                                     <dd>{{ works.out|date:"P" }}</dd>
                                     <dt>Hours worked:</dt>
-                                    <dd>{{ works.total }}</dd>
+                                    <dd>{{ works.total|tickettime }}</dd>
                                 </dl>
                             {% endif %}
                             </div>
@@ -111,7 +115,7 @@
                             {% endfor %}
                             <tr style="background-color:white;">
                                 <td><strong>Total</strong></td>
-                                <td colspan="3"><strong>{{ works.total }}</strong></td>
+                                <td colspan="3"><strong>{{ works.total|tickettime }}</strong></td>
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
-  Fixed left panel content/text layout positioning
-  Changed total hours format from "hh:mm:ss" to "h m"

Before:
![ts_now](https://cloud.githubusercontent.com/assets/229226/7712693/c6fdcc94-fe27-11e4-84c1-a8ca6c6a3080.png)

After:
![ts_fixed](https://cloud.githubusercontent.com/assets/229226/7712696/cb5dd1f8-fe27-11e4-9761-64277a82495d.png)

